### PR TITLE
Refactor tests and refresh token logic, set env vars

### DIFF
--- a/api/src/__test__/helpers/helpers.ts
+++ b/api/src/__test__/helpers/helpers.ts
@@ -1,7 +1,6 @@
 import { prisma } from '../../utils/prisma';
-import { registerUser } from '../../services/auth';
+import { registerUser, createAccessToken } from '../../services/auth';
 import { IRegisterUser } from '@hour-tracker/core-types/api/auth';
-import supertest from 'supertest';
 import { Role } from '@prisma/client';
 
 async function createOrganizations() {
@@ -51,17 +50,8 @@ async function createUserForOrganization(orgId: string, options = {}) {
   return registerUser(params);
 }
 
-async function loginTestUser(
-  app: Express.Application,
-  emailAddress: string,
-): Promise<string> {
-  return supertest(app)
-    .post('/api/v0/auth/signin')
-    .send({
-      emailAddress,
-      password: '12345',
-    })
-    .then((res) => res.body.accessToken);
+function loginTestUser(userId: string): string {
+  return createAccessToken(userId);
 }
 
 export {

--- a/api/src/__test__/integration/activities.spec.ts
+++ b/api/src/__test__/integration/activities.spec.ts
@@ -17,7 +17,7 @@ describe('activities controller', () => {
   beforeEach(async () => {
     [organization, otherOrganization] = await createOrganizations();
     const testUser = await createUserForOrganization(organization.id);
-    token = await loginTestUser(app, testUser.emailAddress);
+    token = loginTestUser(testUser.id);
   });
 
   describe('createActivity', () => {

--- a/api/src/__test__/integration/members.spec.ts
+++ b/api/src/__test__/integration/members.spec.ts
@@ -17,7 +17,7 @@ describe('createMember', () => {
   beforeEach(async () => {
     [organization, otherOrganization] = await createOrganizations();
     const testUser = await createUserForOrganization(organization.id);
-    token = await loginTestUser(app, testUser.emailAddress);
+    token = loginTestUser(testUser.id);
   });
 
   it('should create one member', async () => {

--- a/api/src/__test__/integration/organizations.spec.ts
+++ b/api/src/__test__/integration/organizations.spec.ts
@@ -21,8 +21,8 @@ describe('createOrganization', () => {
       emailAddress: 'admin@user.com',
       role: Role.ADMIN,
     });
-    token = await loginTestUser(app, testUser.emailAddress);
-    adminUserToken = await loginTestUser(app, adminUser.emailAddress);
+    token = loginTestUser(testUser.id);
+    adminUserToken = loginTestUser(adminUser.id);
   });
 
   it('should create an organization', async () => {

--- a/api/src/__test__/integration/timelogs.spec.ts
+++ b/api/src/__test__/integration/timelogs.spec.ts
@@ -18,7 +18,7 @@ describe('activities controller', () => {
   beforeEach(async () => {
     [organization, otherOrganization] = await createOrganizations();
     const testUser = await createUserForOrganization(organization.id);
-    token = await loginTestUser(app, testUser.emailAddress);
+    token = loginTestUser(testUser.id);
   });
 
   describe('createTimeLogForDate', () => {

--- a/api/src/controllers/Auth/index.ts
+++ b/api/src/controllers/Auth/index.ts
@@ -1,7 +1,10 @@
 import { Request, Response, Router } from 'express';
 import asyncHandler from '../../utils/asyncHandler';
 import { getRefreshToken, registerUser, userSignIn } from '../../services/auth';
-import { IUserCreated } from '@hour-tracker/core-types/api/auth';
+import {
+  IReqRefreshToken,
+  IUserCreated,
+} from '@hour-tracker/core-types/api/auth';
 import { authorize, protect } from '../../middleware/authHandler';
 import { ROLES } from '@hour-tracker/core-constants/roles';
 
@@ -28,7 +31,8 @@ const signIn = asyncHandler(async (req: Request, res: Response) => {
  * Route for getting a new refresh token
  */
 const refreshToken = asyncHandler(async (req: Request, res: Response) => {
-  const { accessToken } = await getRefreshToken(req.cookies.rtc);
+  const { grant_type }: IReqRefreshToken = req.body;
+  const { accessToken } = await getRefreshToken(req.cookies.rtc, grant_type);
   res.status(200).json({ accessToken });
 });
 
@@ -37,6 +41,6 @@ const router = Router();
 
 router.route('/register').post(protect, authorize(ROLES.ADMIN), register);
 router.route('/signin').post(signIn);
-router.route('/refresh-token').get(refreshToken);
+router.route('/refresh-token').post(refreshToken);
 
 export default router;

--- a/api/src/middleware/authHandler.ts
+++ b/api/src/middleware/authHandler.ts
@@ -15,7 +15,10 @@ const protect = async (req: Request, res: Response, next: NextFunction) => {
   }
 
   try {
-    const { userId }: any = verify(token, 'ACCESS_VAR_HERE');
+    const { userId }: any = verify(
+      token,
+      process.env.ACCESS_TOKEN_KEY as string,
+    );
     req.user = await getUser(userId);
     next();
   } catch (error) {

--- a/api/src/services/auth.ts
+++ b/api/src/services/auth.ts
@@ -10,6 +10,7 @@ import { compare, hash } from 'bcryptjs';
 import { ErrorResponse } from '../utils/error';
 import { sign, verify } from 'jsonwebtoken';
 import { getUser } from './user';
+import { API_GRANT_TYPES } from '@hour-tracker/core-constants/shared';
 
 async function registerUser({
   emailAddress,
@@ -63,7 +64,7 @@ function createAccessToken(userId: string) {
     {
       userId,
     },
-    'ACCESS_VAR_HERE',
+    process.env.ACCESS_TOKEN_KEY as string,
     { expiresIn: '15m' },
   );
 }
@@ -74,20 +75,27 @@ function createRefreshToken(userId: string) {
     {
       userId,
     },
-    'REFRESH_VAR_HERE',
+    process.env.REFRESH_TOKEN_KEY as string,
     { expiresIn: '1d' },
   );
 }
 
-async function getRefreshToken(token: string): Promise<IRefreshTokenSuccess> {
+async function getRefreshToken(
+  token: string,
+  grantType: string,
+): Promise<IRefreshTokenSuccess> {
   let payload: any = null;
 
   if (!token) {
     throw new ErrorResponse('MissingInformation', 400);
   }
 
+  if (API_GRANT_TYPES.REFRESH_TOKEN !== grantType) {
+    throw new ErrorResponse('MissingInformation', 400);
+  }
+
   try {
-    payload = verify(token, 'REFRESH_VAR_HERE');
+    payload = verify(token, process.env.REFRESH_TOKEN_KEY as string);
   } catch (error) {
     throw new ErrorResponse('InvalidInformation', 401);
   }
@@ -99,4 +107,4 @@ async function getRefreshToken(token: string): Promise<IRefreshTokenSuccess> {
   };
 }
 
-export { registerUser, userSignIn, getRefreshToken };
+export { registerUser, userSignIn, getRefreshToken, createAccessToken };

--- a/core/constants/shared.ts
+++ b/core/constants/shared.ts
@@ -1,0 +1,5 @@
+const API_GRANT_TYPES = {
+  REFRESH_TOKEN: 'refresh_token',
+};
+
+export { API_GRANT_TYPES };

--- a/core/types/api/auth/index.ts
+++ b/core/types/api/auth/index.ts
@@ -27,6 +27,10 @@ export interface ISignInSuccess {
   refreshToken: string;
 }
 
+export interface IReqRefreshToken {
+  grant_type: string;
+}
+
 export interface IRefreshTokenSuccess {
   accessToken: string;
 }

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -33,6 +33,8 @@ services:
     environment:
       - NODE_ENV=development
       - PORT=5000
+      - REFRESH_TOKEN_KEY=localdockerenvrefresh
+      - ACCESS_TOKEN_KEY=localdockerenvaccess
     ports:
       - '5000:5000'
     volumes:


### PR DESCRIPTION
- Changes refresh token route to a post as per [reference](https://www.oauth.com/oauth2-servers/making-authenticated-requests/refreshing-an-access-token/#:~:text=To%20use%20the%20refresh%20token,the%20client%20credentials%20if%20required.), added grant_type to body
- Refactor tests to just get the access token
- Set env vars for token secrets