### PR TITLE
fix(ci): skip CI runs for dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,10 +8,9 @@ updates:
     commit-message:
       prefix: "chore(deps)"
     groups:
-      dev-dependencies:
-        dependency-type: "development"
-      production-dependencies:
-        dependency-type: "production"
+      dependencies:
+        patterns:
+          - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   run_tests:
+    if: github.actor != 'dependabot[bot]'
     uses: ./.github/workflows/ci_tests.yml
 
   reset_neon_testing_branch:


### PR DESCRIPTION
closes #163 
- exclude CI runs for dependabot 

Secrets are scoped differently for dependabot generated actions, which will fail a few CI steps relying on their values. This change will require manual runs of CI but keeps the secrets separate.